### PR TITLE
Merge results from two repositories

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,12 @@
             <artifactId>json4s-ext_2.12</artifactId>
         </dependency>
 
+        <!-- http -->
+        <dependency>
+            <groupId>org.scalaj</groupId>
+            <artifactId>scalaj-http_2.12</artifactId>
+        </dependency>
+
         <!-- joda -->
         <dependency>
             <groupId>joda-time</groupId>

--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -7,6 +7,8 @@
 daemon.http.port=8012
 graphql.profiling.threshold=100
 
+pidgraph.url=https://test.pidgraph.narcis.nl
+
 sysvsoi.database.driver-class=com.mysql.jdbc.Driver
 sysvsoi.database.url=jdbc:mysql://tvsoi11.dans.knaw.nl:3306/sysvsoi
 sysvsoi.database.username=narcis_portal

--- a/src/main/scala/nl/knaw/dans/narcis/graphql/Configuration.scala
+++ b/src/main/scala/nl/knaw/dans/narcis/graphql/Configuration.scala
@@ -27,6 +27,7 @@ case class Configuration(version: String,
                          serverPort: Int,
                          profilingThreshold: FiniteDuration,
                          sysvsoiConfig: DatabaseConfiguration,
+                         pidGraphUrl: String
                         )
 
 object Configuration {
@@ -52,6 +53,7 @@ object Configuration {
         properties.getString("sysvsoi.database.username"),
         properties.getString("sysvsoi.database.password"),
       ),
+      pidGraphUrl = properties.getString("pidgraph.url"),
     )
   }
 }

--- a/src/main/scala/nl/knaw/dans/narcis/graphql/app/database/VsoiDb.scala
+++ b/src/main/scala/nl/knaw/dans/narcis/graphql/app/database/VsoiDb.scala
@@ -19,18 +19,19 @@ import java.sql.{Connection, ResultSet}
 
 import nl.knaw.dans.lib.error._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
-import nl.knaw.dans.narcis.graphql.app.model.Person
+import nl.knaw.dans.narcis.graphql.app.model.{ExternalPersonId, Person, PersonIdType}
 import org.joda.time.LocalDate
 import resource.{ManagedResource, managed}
 
-import scala.util.Try
+import scala.util.{Success, Try}
 
 class VsoiDb() extends DebugEnhancedLogging {
 
+  // Note that this is without the external identifiers
   def getPerson(prsId: String)(implicit connection: Connection): Try[Option[Person]] = {
     trace(prsId)
 
-    // TODO get email, optional
+    // TODO get all info
     val query = "SELECT achternaam, email FROM persoon WHERE pers_id=?;"
     val managedResultSet: ManagedResource[ResultSet] = for {
           prepStatement <- managed(connection.prepareStatement(query))
@@ -38,7 +39,7 @@ class VsoiDb() extends DebugEnhancedLogging {
           resultSet <- managed(prepStatement.executeQuery())
         } yield resultSet
 
-    // Note that we only get the achternaam, the rest is FAKE!
+    // Note that we only get some fields, the rest is FAKE!
     managedResultSet.map(resultSet => {
       if (resultSet.next()) {
         val name = resultSet.getString("achternaam")
@@ -52,31 +53,64 @@ class VsoiDb() extends DebugEnhancedLogging {
   }
 
 
-//  def getExternalIdentifiers(prsId: String)
-//                            (implicit connection: Connection): Try[Seq[String]] = {
-//    trace(prsId)
-//
-//    val query = "Select extern_id from persoon_externid where pers_id=?;"
-//    val resultSet = for {
-//      prepStatement <- managed(connection.prepareStatement(query))
-//      _ = prepStatement.setString(1, prsId)
-//      resultSet <- managed(prepStatement.executeQuery())
-//    } yield resultSet
-//
-//    resultSet.map(resultSet => {
-//      /*
-//       * Stream.continually(...).takeWhile(b => b) is equivalent to Java's while-loop: it checks
-//       * whether there is a next result and continues doing this until resultSet.next() returns false.
-//       */
-//      Stream.continually(resultSet.next())
-//        .takeWhile(b => b)
-//        .flatMap(_ =>
-//          resultSet.getString("extern_id")
-//        )
-//        .toList // We can't leave it as a Stream, but need to convert to a List, since the resources are closed on calling .tried
-//    }
-//    ).tried
-//  }
-//
+  // NOTE copied all from the aggregator scala code... only minor changes!
+
+
+  def getExternalIdentifiers(prsId: String)
+                            (implicit connection: Connection): Try[Seq[ExternalPersonId]] = {
+    trace(prsId)
+
+    val query = "Select extern_id from persoon_externid where pers_id=?;"
+    val resultSet = for {
+      prepStatement <- managed(connection.prepareStatement(query))
+      _ = prepStatement.setString(1, prsId)
+      resultSet <- managed(prepStatement.executeQuery())
+    } yield resultSet
+
+    resultSet.map(resultSet => {
+      /*
+       * Stream.continually(...).takeWhile(b => b) is equivalent to Java's while-loop: it checks
+       * whether there is a next result and continues doing this until resultSet.next() returns false.
+       */
+      Stream.continually(resultSet.next())
+        .takeWhile(b => b)
+        .flatMap(_ =>
+          extPersIdfromVsoiIdString(resultSet.getString("extern_id"))
+        )
+        .toList // We can't leave it as a Stream, but need to convert to a List, since the resources are closed on calling .tried
+    }
+    ).tried
+  }
+
+  private def extPersIdfromVsoiIdString(identifier: String): Option[ExternalPersonId] = {
+    getStrippedPersIdfromVsoiIdString(identifier)
+      .flatMap(epid =>
+        getNormalisedPersId(epid).doIfFailure {
+          case e =>
+            logger.warn(s"Ignoring VSOI pers id: (type, value) = ('${ epid.idType }', '${ epid.idValue }'), because it could not be converted to an external pers id: ${ e.getMessage }")
+        }.toOption
+      )
+  }
+
+  private def getStrippedPersIdfromVsoiIdString(identifier: String): Option[ExternalPersonId] = {
+    // SysVsoi person identifier types; discovered by inspection of database output
+    identifier.replaceAll("\n", "").trim.toLowerCase match {
+      case dai if dai.startsWith("dai") => Some(ExternalPersonId(PersonIdType.dai_nl, dai.stripPrefix("dai")))
+      case isni if isni.startsWith("isni") => Some(ExternalPersonId(PersonIdType.isni, isni.stripPrefix("isni")))
+      case orcid if orcid.startsWith("orcid") => Some(ExternalPersonId(PersonIdType.orcid, orcid.stripPrefix("orcid")))
+      case loop if loop.startsWith("loop") => Some(ExternalPersonId(PersonIdType.loop, loop.stripPrefix("loop")))
+      case viaf if viaf.startsWith("viaf") => Some(ExternalPersonId(PersonIdType.viaf, viaf.stripPrefix("viaf")))
+      case scopus if scopus.startsWith("scopus") => Some(ExternalPersonId(PersonIdType.scopus, scopus.stripPrefix("scopus")))
+      case ror if ror.startsWith("ror") => Some(ExternalPersonId(PersonIdType.ror, ror.stripPrefix("ror")))
+      case _ => None
+    }
+  }
+
+  private def getNormalisedPersId(pid: ExternalPersonId): Try[ExternalPersonId] = {
+    Success(pid) // no normalisation!!!
+
+//    pidNormaliser.normalisePersonPid(pid.idType, pid.idValue)
+//      .map(ExternalPersonId(pid.idType, _))
+  }
 
 }

--- a/src/main/scala/nl/knaw/dans/narcis/graphql/app/graphql/GraphQLSchema.scala
+++ b/src/main/scala/nl/knaw/dans/narcis/graphql/app/graphql/GraphQLSchema.scala
@@ -17,16 +17,17 @@ package nl.knaw.dans.narcis.graphql.app.graphql
 
 import java.util.UUID
 
-import nl.knaw.dans.narcis.graphql.app.graphql.resolvers.{ PersonResolver, WorkResolver }
-import nl.knaw.dans.narcis.graphql.app.graphql.types.{ GraphQLPerson, GraphQLWork, Mutation, Query }
-import nl.knaw.dans.narcis.graphql.app.model.{ InputPerson, InputWork }
+import nl.knaw.dans.narcis.graphql.app.graphql.resolvers.{PersonResolver, WorkResolver}
+import nl.knaw.dans.narcis.graphql.app.graphql.types.{GraphQLExternalPersonId, GraphQLPerson, GraphQLWork, Mutation, Query}
+import nl.knaw.dans.narcis.graphql.app.model.PersonIdType.PersonIdType
+import nl.knaw.dans.narcis.graphql.app.model.{InputPerson, InputWork, PersonIdType}
 import org.joda.time.LocalDate
 import sangria.ast.StringValue
 import sangria.execution.deferred.DeferredResolver
-import sangria.macros.derive.{ DocumentInputField, _ }
+import sangria.macros.derive.{DocumentInputField, _}
 import sangria.marshalling.FromInput
-import sangria.schema.{ InputObjectType, ObjectType, ScalarType, Schema }
-import sangria.validation.{ StringCoercionViolation, ValueCoercionViolation, Violation }
+import sangria.schema.{InputObjectType, ObjectType, ScalarType, Schema}
+import sangria.validation.{StringCoercionViolation, ValueCoercionViolation, Violation}
 
 import scala.util.Try
 
@@ -75,6 +76,15 @@ object GraphQLSchema {
       }
     )
   }
+
+  implicit val PersonIdTypeType = deriveEnumType[PersonIdType.Value](
+    EnumTypeDescription("The type of person (author) identifier"),
+    DocumentValue("dai_nl", "Digital Author Identifier (DAI), but specific for The Netherlands"),
+    DocumentValue("orcid", "Open Researcher and Contributor ID (ORCID)"),
+    // TODO all the others...
+  )
+
+  implicit val GraphQLExternalPersonIdType: ObjectType[DataContext, GraphQLExternalPersonId] = deriveObjectType[DataContext, GraphQLExternalPersonId]()
 
   implicit val GraphQLPersonType: ObjectType[DataContext, GraphQLPerson] = deriveObjectType[DataContext, GraphQLPerson]()
   implicit val InputPersonType: InputObjectType[InputPerson] = deriveInputObjectType[InputPerson](

--- a/src/main/scala/nl/knaw/dans/narcis/graphql/app/graphql/types/GraphQLExternalPersonId.scala
+++ b/src/main/scala/nl/knaw/dans/narcis/graphql/app/graphql/types/GraphQLExternalPersonId.scala
@@ -1,0 +1,32 @@
+/**
+ * Copyright (C) 2019 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.narcis.graphql.app.graphql.types
+
+import nl.knaw.dans.narcis.graphql.app.model.ExternalPersonId
+import sangria.macros.derive.{GraphQLDescription, GraphQLField, GraphQLName}
+
+@GraphQLName("ExternalPersonId")
+@GraphQLDescription("The identifier for a person, mostly author identifiers")
+class GraphQLExternalPersonId(externalPersonId: ExternalPersonId) {
+
+  @GraphQLField
+  @GraphQLDescription("The type of identifier, specific for a registration authority")
+  val idType = externalPersonId.idType
+
+  @GraphQLField
+  @GraphQLDescription("The actual identifier (unique code)")
+  val value = externalPersonId.value
+}

--- a/src/main/scala/nl/knaw/dans/narcis/graphql/app/graphql/types/GraphQLExternalPersonId.scala
+++ b/src/main/scala/nl/knaw/dans/narcis/graphql/app/graphql/types/GraphQLExternalPersonId.scala
@@ -23,10 +23,12 @@ import sangria.macros.derive.{GraphQLDescription, GraphQLField, GraphQLName}
 class GraphQLExternalPersonId(externalPersonId: ExternalPersonId) {
 
   @GraphQLField
-  @GraphQLDescription("The type of identifier, specific for a registration authority")
+  @GraphQLName("type")
+  @GraphQLDescription("The type of identifier, specific for a registration authority or organisation")
   val idType = externalPersonId.idType
 
   @GraphQLField
+  @GraphQLName("value")
   @GraphQLDescription("The actual identifier (unique code)")
-  val value = externalPersonId.value
+  val idValue = externalPersonId.idValue
 }

--- a/src/main/scala/nl/knaw/dans/narcis/graphql/app/graphql/types/GraphQLPerson.scala
+++ b/src/main/scala/nl/knaw/dans/narcis/graphql/app/graphql/types/GraphQLPerson.scala
@@ -27,6 +27,7 @@ import sangria.schema.{ Context, DeferredValue }
 class GraphQLPerson(private val person: Person) {
 
   @GraphQLField
+  @GraphQLName("id")
   @GraphQLDescription("The identifier with which this person is associated.")
   val personId: PersonId = person.personId
 
@@ -47,9 +48,10 @@ class GraphQLPerson(private val person: Person) {
   val place: String = person.place
 
   @GraphQLField
-  @GraphQLDescription("")
+  @GraphQLDescription("The external identifiers of this person")
   def externalIds(implicit ctx: Context[DataContext, GraphQLPerson]): Seq[GraphQLExternalPersonId] = {
-    ???
+    // without a resolver...
+    ctx.ctx.repo.personDao.getExtIds(person.personId).map(new GraphQLExternalPersonId(_))
   }
 
 //  @GraphQLField

--- a/src/main/scala/nl/knaw/dans/narcis/graphql/app/graphql/types/GraphQLPerson.scala
+++ b/src/main/scala/nl/knaw/dans/narcis/graphql/app/graphql/types/GraphQLPerson.scala
@@ -17,10 +17,11 @@ package nl.knaw.dans.narcis.graphql.app.graphql.types
 
 import nl.knaw.dans.narcis.graphql.app.graphql.DataContext
 import nl.knaw.dans.narcis.graphql.app.graphql.resolvers.WorkResolver
-import nl.knaw.dans.narcis.graphql.app.model.{ Person, PersonId }
+import nl.knaw.dans.narcis.graphql.app.model.PersonIdType.PersonIdType
+import nl.knaw.dans.narcis.graphql.app.model.{Person, PersonId, PersonIdType}
 import org.joda.time.LocalDate
-import sangria.macros.derive.{ GraphQLDescription, GraphQLField, GraphQLName }
-import sangria.schema.{ Context, DeferredValue }
+import sangria.macros.derive.{GraphQLDescription, GraphQLField, GraphQLName}
+import sangria.schema.{Context, DeferredValue}
 
 @GraphQLName("Person")
 @GraphQLDescription("The object containing data about the person.")
@@ -50,32 +51,20 @@ class GraphQLPerson(private val person: Person) {
   @GraphQLField
   @GraphQLDescription("The external identifiers of this person")
   def externalIds(implicit ctx: Context[DataContext, GraphQLPerson]): Seq[GraphQLExternalPersonId] = {
-    // without a resolver...
+    // without a resolver
     ctx.ctx.repo.personDao.getExtIds(person.personId).map(new GraphQLExternalPersonId(_))
   }
 
-//  @GraphQLField
-//  @GraphQLDescription("")
-//  def externalId(`type`: ExternalPersonIdType)(implicit ctx: Context[DataContext, GraphQLPerson]): Seq[GraphQLExternalPersonId] = {
-//    ???
-//  }
-
-  /*
-    query GetPersonData {
-      person(id: "PRS12345") {
-        id
-        name
-        externalIds {
-          type
-          value
-        }
-        externalId(type: ORCID) {
-          type
-          value
-        }
-      }
-    }
-   */
+  @GraphQLField
+  @GraphQLDescription("External identifiers of a specified type")
+  def externalIdsByType(@GraphQLName("type") idType: PersonIdType)
+                       (implicit ctx: Context[DataContext, GraphQLPerson]): Seq[GraphQLExternalPersonId] = {
+    // also without a resolver
+    // using a filter here, might be suboptimal, maybe do it in the repo or db?
+    ctx.ctx.repo.personDao.getExtIds(person.personId)
+      .filter(eId => eId.idType == idType)
+      .map(new GraphQLExternalPersonId(_))
+  }
 
   // NOTE: toggle between these 2 implementations and see the difference
   //  in the number of interactions with the DAO

--- a/src/main/scala/nl/knaw/dans/narcis/graphql/app/graphql/types/GraphQLPerson.scala
+++ b/src/main/scala/nl/knaw/dans/narcis/graphql/app/graphql/types/GraphQLPerson.scala
@@ -46,12 +46,12 @@ class GraphQLPerson(private val person: Person) {
   @GraphQLDescription("The city/town where this person lives.")
   val place: String = person.place
 
-//  @GraphQLField
-//  @GraphQLDescription("")
-//  def externalIds(implicit ctx: Context[DataContext, GraphQLPerson]): Seq[GraphQLExternalPersonId] = {
-//    ???
-//  }
-//
+  @GraphQLField
+  @GraphQLDescription("")
+  def externalIds(implicit ctx: Context[DataContext, GraphQLPerson]): Seq[GraphQLExternalPersonId] = {
+    ???
+  }
+
 //  @GraphQLField
 //  @GraphQLDescription("")
 //  def externalId(`type`: ExternalPersonIdType)(implicit ctx: Context[DataContext, GraphQLPerson]): Seq[GraphQLExternalPersonId] = {

--- a/src/main/scala/nl/knaw/dans/narcis/graphql/app/model/ExternalPersonId.scala
+++ b/src/main/scala/nl/knaw/dans/narcis/graphql/app/model/ExternalPersonId.scala
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2019 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.narcis.graphql.app.model
+
+import nl.knaw.dans.narcis.graphql.app.model.PersonIdType.PersonIdType
+
+object PersonIdType extends Enumeration {
+  type PersonIdType = Value
+
+  // @formatter:off
+  val publication   = Value("publication")
+  val dai_nl        = Value("dai-nl")
+  val isni          = Value("isni")
+  val loop          = Value("loop")
+  val nod_person    = Value("nod-person") // this is actually internal!
+  val orcid         = Value("orcid")
+  val researcherid  = Value("researcherid")
+  val scopus        = Value("scopus")
+  val viaf          = Value("viaf")
+  val ror           = Value("ror")
+  // @formatter:on
+}
+
+case class ExternalPersonId(idType: PersonIdType, value: String)

--- a/src/main/scala/nl/knaw/dans/narcis/graphql/app/model/ExternalPersonId.scala
+++ b/src/main/scala/nl/knaw/dans/narcis/graphql/app/model/ExternalPersonId.scala
@@ -34,4 +34,4 @@ object PersonIdType extends Enumeration {
   // @formatter:on
 }
 
-case class ExternalPersonId(idType: PersonIdType, value: String)
+case class ExternalPersonId(idType: PersonIdType, idValue: String)

--- a/src/main/scala/nl/knaw/dans/narcis/graphql/app/model/Person.scala
+++ b/src/main/scala/nl/knaw/dans/narcis/graphql/app/model/Person.scala
@@ -17,6 +17,8 @@ package nl.knaw.dans.narcis.graphql.app.model
 
 import org.joda.time.LocalDate
 
+import scala.collection.mutable.ArrayBuffer
+
 case class Person(personId: PersonId, // for Narcis this is the PRS
                   name: String,
                   email: Option[String],

--- a/src/main/scala/nl/knaw/dans/narcis/graphql/app/repository/PersonDao.scala
+++ b/src/main/scala/nl/knaw/dans/narcis/graphql/app/repository/PersonDao.scala
@@ -15,7 +15,7 @@
  */
 package nl.knaw.dans.narcis.graphql.app.repository
 
-import nl.knaw.dans.narcis.graphql.app.model.{ InputPerson, Person, PersonId }
+import nl.knaw.dans.narcis.graphql.app.model.{ExternalPersonId, InputPerson, Person, PersonId}
 
 trait PersonDao {
 
@@ -24,6 +24,8 @@ trait PersonDao {
   def find(id: PersonId): Option[Person]
 
   def find(ids: Seq[PersonId]): Seq[Person]
+
+  def getExtIds(id: PersonId): Seq[ExternalPersonId]
 
   def store(person: InputPerson): Person
 }

--- a/src/main/scala/nl/knaw/dans/narcis/graphql/app/repository/demo_impl/DemoPersonDao.scala
+++ b/src/main/scala/nl/knaw/dans/narcis/graphql/app/repository/demo_impl/DemoPersonDao.scala
@@ -17,11 +17,12 @@ package nl.knaw.dans.narcis.graphql.app.repository.demo_impl
 
 import java.util.UUID
 
-import nl.knaw.dans.narcis.graphql.app.model.{ InputPerson, Person, PersonId }
+import nl.knaw.dans.narcis.graphql.app.model.{ExternalPersonId, InputPerson, Person, PersonId, PersonIdType}
 import nl.knaw.dans.narcis.graphql.app.repository.PersonDao
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 
 import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
 
 class DemoPersonDao(initalInput: Map[PersonId, Person] = Map.empty) extends PersonDao with DebugEnhancedLogging {
 
@@ -40,6 +41,13 @@ class DemoPersonDao(initalInput: Map[PersonId, Person] = Map.empty) extends Pers
   override def find(ids: Seq[PersonId]): Seq[Person] = {
     trace(ids)
     ids.flatMap(repo.get)
+  }
+
+  override def getExtIds(id: PersonId): Seq[ExternalPersonId] = {
+    trace(id)
+    val fakeId = new ExternalPersonId(PersonIdType.nod_person, "fake-id")
+    List[ExternalPersonId](fakeId, fakeId) // the same fake twice to see if we get a 'distinct' result
+    //ArrayBuffer[ExternalPersonId]()// just empty
   }
 
   override def store(person: InputPerson): Person = {

--- a/src/main/scala/nl/knaw/dans/narcis/graphql/app/repository/narcis_impl/NarcisPersonDao.scala
+++ b/src/main/scala/nl/knaw/dans/narcis/graphql/app/repository/narcis_impl/NarcisPersonDao.scala
@@ -35,7 +35,7 @@ class NarcisPersonDao(vsoi: VsoiPersonDao,
   override def getExtIds(id: PersonId): Seq[ExternalPersonId] = {
     val extIdsFromVsoi = vsoi.getExtIds(id)
     val extIdsFromDemo = demo.getExtIds(id)
-    // TODO merge them, plus deduplicate... only works if normalised
+    // merge them, plus deduplicate... only works if normalised in the same way
     (extIdsFromVsoi.toSet ++ extIdsFromDemo.toSet).toSeq
   }
 

--- a/src/main/scala/nl/knaw/dans/narcis/graphql/app/repository/narcis_impl/NarcisPersonDao.scala
+++ b/src/main/scala/nl/knaw/dans/narcis/graphql/app/repository/narcis_impl/NarcisPersonDao.scala
@@ -15,7 +15,7 @@
  */
 package nl.knaw.dans.narcis.graphql.app.repository.narcis_impl
 
-import nl.knaw.dans.narcis.graphql.app.model.{ InputPerson, Person, PersonId }
+import nl.knaw.dans.narcis.graphql.app.model.{ExternalPersonId, InputPerson, Person, PersonId}
 import nl.knaw.dans.narcis.graphql.app.repository.PersonDao
 import nl.knaw.dans.narcis.graphql.app.repository.demo_impl.DemoPersonDao
 import nl.knaw.dans.narcis.graphql.app.repository.vsoi_impl.VsoiPersonDao
@@ -24,11 +24,20 @@ class NarcisPersonDao(vsoi: VsoiPersonDao,
                       demo: DemoPersonDao,
                      ) extends PersonDao {
 
+  // merge information, but start with VSOI and add only complementary non conflicting info from other sources.
+
   override def getAll: Seq[Person] = ???
 
-  override def find(id: PersonId): Option[Person] = ???
+  override def find(id: PersonId): Option[Person] = vsoi.find(id)
 
-  override def find(ids: Seq[PersonId]): Seq[Person] = ???
+  override def find(ids: Seq[PersonId]): Seq[Person] = vsoi.find(ids)
+
+  override def getExtIds(id: PersonId): Seq[ExternalPersonId] = {
+    val extIdsFromVsoi = vsoi.getExtIds(id)
+    val extIdsFromDemo = demo.getExtIds(id)
+    // TODO merge them, plus deduplicate... only works if normalised
+    (extIdsFromVsoi.toSet ++ extIdsFromDemo.toSet).toSeq
+  }
 
   override def store(person: InputPerson): Person = ???
 }

--- a/src/main/scala/nl/knaw/dans/narcis/graphql/app/repository/narcis_impl/NarcisPersonDao.scala
+++ b/src/main/scala/nl/knaw/dans/narcis/graphql/app/repository/narcis_impl/NarcisPersonDao.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2019 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.knaw.dans.narcis.graphql.app.repository.narcis_impl
 
 import nl.knaw.dans.narcis.graphql.app.model.{ InputPerson, Person, PersonId }

--- a/src/main/scala/nl/knaw/dans/narcis/graphql/app/repository/narcis_impl/NarcisPersonDao.scala
+++ b/src/main/scala/nl/knaw/dans/narcis/graphql/app/repository/narcis_impl/NarcisPersonDao.scala
@@ -18,10 +18,11 @@ package nl.knaw.dans.narcis.graphql.app.repository.narcis_impl
 import nl.knaw.dans.narcis.graphql.app.model.{ExternalPersonId, InputPerson, Person, PersonId}
 import nl.knaw.dans.narcis.graphql.app.repository.PersonDao
 import nl.knaw.dans.narcis.graphql.app.repository.demo_impl.DemoPersonDao
+import nl.knaw.dans.narcis.graphql.app.repository.pigraph_impl.PidGraphpersonDao
 import nl.knaw.dans.narcis.graphql.app.repository.vsoi_impl.VsoiPersonDao
 
 class NarcisPersonDao(vsoi: VsoiPersonDao,
-                      demo: DemoPersonDao,
+                      pidgraph: PidGraphpersonDao
                      ) extends PersonDao {
 
   // merge information, but start with VSOI and add only complementary non conflicting info from other sources.
@@ -34,9 +35,10 @@ class NarcisPersonDao(vsoi: VsoiPersonDao,
 
   override def getExtIds(id: PersonId): Seq[ExternalPersonId] = {
     val extIdsFromVsoi = vsoi.getExtIds(id)
-    val extIdsFromDemo = demo.getExtIds(id)
+    val extIdsFromPidgraph = pidgraph.getExtIds(id)
+
     // merge them, plus deduplicate... only works if normalised in the same way
-    (extIdsFromVsoi.toSet ++ extIdsFromDemo.toSet).toSeq
+    (extIdsFromVsoi.toSet ++ extIdsFromPidgraph.toSet).toSeq
   }
 
   override def store(person: InputPerson): Person = ???

--- a/src/main/scala/nl/knaw/dans/narcis/graphql/app/repository/narcis_impl/NarcisRepo.scala
+++ b/src/main/scala/nl/knaw/dans/narcis/graphql/app/repository/narcis_impl/NarcisRepo.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2019 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.knaw.dans.narcis.graphql.app.repository.narcis_impl
 
 import java.sql.Connection

--- a/src/main/scala/nl/knaw/dans/narcis/graphql/app/repository/narcis_impl/NarcisRepo.scala
+++ b/src/main/scala/nl/knaw/dans/narcis/graphql/app/repository/narcis_impl/NarcisRepo.scala
@@ -19,17 +19,18 @@ import java.sql.Connection
 
 import nl.knaw.dans.narcis.graphql.app.database.VsoiDb
 import nl.knaw.dans.narcis.graphql.app.repository.Repository
-import nl.knaw.dans.narcis.graphql.app.repository.demo_impl.{ DemoPersonDao, DemoWorkDao }
+import nl.knaw.dans.narcis.graphql.app.repository.demo_impl.{DemoPersonDao, DemoWorkDao}
+import nl.knaw.dans.narcis.graphql.app.repository.pigraph_impl.PidGraphpersonDao
 import nl.knaw.dans.narcis.graphql.app.repository.vsoi_impl.VsoiPersonDao
 
 class NarcisRepo(vsoiDb: VsoiDb)(implicit connection: Connection) {
 
   def repository: Repository = {
     val vsoiPersonDao = new VsoiPersonDao(vsoiDb)
-    val demoPersonDao = new DemoPersonDao() // TODO replace with DAOs that get person data from other sources
-    
+    val pidGraphPersonDao = new PidGraphpersonDao()
+
     Repository(
-      new NarcisPersonDao(vsoiPersonDao, demoPersonDao),
+      new NarcisPersonDao(vsoiPersonDao, pidGraphPersonDao),
       new DemoWorkDao() // TODO replace with NarcisWorkDao, which combines the data from various sources
     )
   }

--- a/src/main/scala/nl/knaw/dans/narcis/graphql/app/repository/pigraph_impl/PidGraphpersonDao.scala
+++ b/src/main/scala/nl/knaw/dans/narcis/graphql/app/repository/pigraph_impl/PidGraphpersonDao.scala
@@ -1,0 +1,81 @@
+/**
+ * Copyright (C) 2019 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.narcis.graphql.app.repository.pigraph_impl
+
+import nl.knaw.dans.lib.logging.DebugEnhancedLogging
+import nl.knaw.dans.narcis.graphql.Command.configuration
+import nl.knaw.dans.narcis.graphql.app.model.{ExternalPersonId, InputPerson, Person, PersonId, PersonIdType}
+import nl.knaw.dans.narcis.graphql.app.repository.PersonDao
+import nl.knaw.dans.narcis.graphql.app.rest.{GraphPerson, GraphPersonPid, HttpWorker, PidGraphData}
+import org.apache.commons.lang.NotImplementedException
+import org.json4s.Formats
+
+import scala.util.{Failure, Success, Try}
+
+class PidGraphpersonDao extends PersonDao with DebugEnhancedLogging {
+  implicit val formats: Formats = PidGraphData.jsonFormats
+
+  override def getAll: Seq[Person] = ???
+
+  override def find(id: PersonId): Option[Person] = {
+    // not much 'person' information available here, just that it is in there might be interesting to know
+    ???
+  }
+
+  override def find(ids: Seq[PersonId]): Seq[Person] = ???
+
+  override def getExtIds(id: PersonId): Seq[ExternalPersonId] = {
+    trace(id)
+
+    // this is what we can get additional information on here
+    // get data from the pidgraph rest api
+    val dataFetcher = new HttpWorker(configuration.version)
+    val pidGraphPerson = dataFetcher.getJsonData[GraphPerson](s"https://test.pidgraph.narcis.nl/person/$id")
+    // extract ext ids
+    pidGraphPerson match {
+      case Success(pgd) => {
+        pgd.pids.map(pgPid => ExternalPersonIdFromPidGraphPersonId(pgPid)).flatMap(_.toOption)
+      }
+      case Failure(exception) => {
+        logger.warn(s"Failed getting external identifiers for person $id, error: ${exception.getMessage}")
+        Seq.empty[ExternalPersonId]
+      }
+    }
+  }
+
+  def ExternalPersonIdFromPidGraphPersonId(pgPid: GraphPersonPid): Try[ExternalPersonId] = Try {
+    trace(pgPid)
+
+    val idType = pgPid.pidType match {
+      case nl.knaw.dans.narcis.graphql.app.rest.PersonPidType.orcid => PersonIdType.orcid
+      case nl.knaw.dans.narcis.graphql.app.rest.PersonPidType.dai_nl => PersonIdType.dai_nl
+      case nl.knaw.dans.narcis.graphql.app.rest.PersonPidType.isni => PersonIdType.isni
+      case nl.knaw.dans.narcis.graphql.app.rest.PersonPidType.loop => PersonIdType.loop
+      case nl.knaw.dans.narcis.graphql.app.rest.PersonPidType.nod_person => PersonIdType.nod_person
+      case nl.knaw.dans.narcis.graphql.app.rest.PersonPidType.publication => PersonIdType.publication
+      case nl.knaw.dans.narcis.graphql.app.rest.PersonPidType.researcherid => PersonIdType.researcherid
+      case nl.knaw.dans.narcis.graphql.app.rest.PersonPidType.scopus => PersonIdType.scopus
+      case nl.knaw.dans.narcis.graphql.app.rest.PersonPidType.viaf => PersonIdType.viaf
+      case _ =>
+        logger.warn(s"No mapping implemented for Person Pid type ${pgPid.pidType}")
+        throw new NotImplementedException(s"No mapping implemented for Person Pid type ${pgPid.pidType}")
+    }
+
+    new ExternalPersonId(idType, pgPid.value) // assume pidgraph is normalized
+  }
+
+  override def store(person: InputPerson): Person = ???
+}

--- a/src/main/scala/nl/knaw/dans/narcis/graphql/app/repository/pigraph_impl/PidGraphpersonDao.scala
+++ b/src/main/scala/nl/knaw/dans/narcis/graphql/app/repository/pigraph_impl/PidGraphpersonDao.scala
@@ -19,7 +19,7 @@ import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import nl.knaw.dans.narcis.graphql.Command.configuration
 import nl.knaw.dans.narcis.graphql.app.model.{ExternalPersonId, InputPerson, Person, PersonId, PersonIdType}
 import nl.knaw.dans.narcis.graphql.app.repository.PersonDao
-import nl.knaw.dans.narcis.graphql.app.rest.{GraphPerson, GraphPersonPid, HttpWorker, PidGraphData}
+import nl.knaw.dans.narcis.graphql.app.rest.{GraphPerson, GraphPersonPid, HttpWorker, PersonPidType, PidGraphData}
 import org.apache.commons.lang.NotImplementedException
 import org.json4s.Formats
 
@@ -43,7 +43,7 @@ class PidGraphpersonDao extends PersonDao with DebugEnhancedLogging {
     // this is what we can get additional information on here
     // get data from the pidgraph rest api
     val dataFetcher = new HttpWorker(configuration.version)
-    val pidGraphPerson = dataFetcher.getJsonData[GraphPerson](s"https://test.pidgraph.narcis.nl/person/$id")
+    val pidGraphPerson = dataFetcher.getJsonData[GraphPerson](s"${configuration.pidGraphUrl}/person/$id")
     // extract ext ids
     pidGraphPerson match {
       case Success(pgd) => {
@@ -60,21 +60,21 @@ class PidGraphpersonDao extends PersonDao with DebugEnhancedLogging {
     trace(pgPid)
 
     val idType = pgPid.pidType match {
-      case nl.knaw.dans.narcis.graphql.app.rest.PersonPidType.orcid => PersonIdType.orcid
-      case nl.knaw.dans.narcis.graphql.app.rest.PersonPidType.dai_nl => PersonIdType.dai_nl
-      case nl.knaw.dans.narcis.graphql.app.rest.PersonPidType.isni => PersonIdType.isni
-      case nl.knaw.dans.narcis.graphql.app.rest.PersonPidType.loop => PersonIdType.loop
-      case nl.knaw.dans.narcis.graphql.app.rest.PersonPidType.nod_person => PersonIdType.nod_person
-      case nl.knaw.dans.narcis.graphql.app.rest.PersonPidType.publication => PersonIdType.publication
-      case nl.knaw.dans.narcis.graphql.app.rest.PersonPidType.researcherid => PersonIdType.researcherid
-      case nl.knaw.dans.narcis.graphql.app.rest.PersonPidType.scopus => PersonIdType.scopus
-      case nl.knaw.dans.narcis.graphql.app.rest.PersonPidType.viaf => PersonIdType.viaf
+      case PersonPidType.orcid => PersonIdType.orcid
+      case PersonPidType.dai_nl => PersonIdType.dai_nl
+      case PersonPidType.isni => PersonIdType.isni
+      case PersonPidType.loop => PersonIdType.loop
+      case PersonPidType.nod_person => PersonIdType.nod_person
+      case PersonPidType.publication => PersonIdType.publication
+      case PersonPidType.researcherid => PersonIdType.researcherid
+      case PersonPidType.scopus => PersonIdType.scopus
+      case PersonPidType.viaf => PersonIdType.viaf
       case _ =>
         logger.warn(s"No mapping implemented for Person Pid type ${pgPid.pidType}")
         throw new NotImplementedException(s"No mapping implemented for Person Pid type ${pgPid.pidType}")
     }
 
-    new ExternalPersonId(idType, pgPid.value) // assume pidgraph is normalized
+    new ExternalPersonId(idType, pgPid.value) // assume pidgraph value is normalized
   }
 
   override def store(person: InputPerson): Person = ???

--- a/src/main/scala/nl/knaw/dans/narcis/graphql/app/repository/vsoi_impl/VsoiPersonDao.scala
+++ b/src/main/scala/nl/knaw/dans/narcis/graphql/app/repository/vsoi_impl/VsoiPersonDao.scala
@@ -18,14 +18,11 @@ package nl.knaw.dans.narcis.graphql.app.repository.vsoi_impl
 import java.sql.Connection
 
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
-import nl.knaw.dans.narcis.graphql.app.model.{ InputPerson, Person, PersonId }
+import nl.knaw.dans.narcis.graphql.app.database.VsoiDb
+import nl.knaw.dans.narcis.graphql.app.model.{ExternalPersonId, InputPerson, Person, PersonId}
 import nl.knaw.dans.narcis.graphql.app.repository.PersonDao
-import org.joda.time.LocalDate
 
-import scala.collection.immutable.Stream.Empty
-import nl.knaw.dans.narcis.graphql.app.database.{ DatabaseAccess, VsoiDb }
-
-import scala.util.{ Failure, Success }
+import scala.util.{Failure, Success}
 
 class VsoiPersonDao(vsoiDb: VsoiDb)(implicit sysVSOIConnection: Connection)  extends PersonDao with DebugEnhancedLogging {
   override def getAll: Seq[Person] = ???
@@ -36,7 +33,6 @@ class VsoiPersonDao(vsoiDb: VsoiDb)(implicit sysVSOIConnection: Connection)  ext
     // fixed fake, always return Alice!
     //Some(Person(id, "Alice", new LocalDate(1990, 1, 1), "London"))
 
-    // TODO get person name from the database
     //vsoiDb.getPerson(id).tried
     vsoiDb.getPerson(id) match {
       case Success(Some(person)) => Some(person) // could do more with person before returning it
@@ -50,7 +46,6 @@ class VsoiPersonDao(vsoiDb: VsoiDb)(implicit sysVSOIConnection: Connection)  ext
       }
     }
 
-
   }
 
   override def find(ids: Seq[PersonId]): Seq[Person] = {
@@ -62,4 +57,14 @@ class VsoiPersonDao(vsoiDb: VsoiDb)(implicit sysVSOIConnection: Connection)  ext
   }
 
   override def store(person: InputPerson): Person = ???
+
+  override def getExtIds(id: PersonId): Seq[ExternalPersonId] = {
+    vsoiDb.getExternalIdentifiers(id) match {
+      case Failure(exception) => {
+        logger.info(s"Failed getting external identifiers for person $id, error: ${exception.getMessage}")
+        Seq.empty[ExternalPersonId]
+      }
+      case Success(eIds) => eIds
+    }
+  }
 }

--- a/src/main/scala/nl/knaw/dans/narcis/graphql/app/rest/HttpWorker.scala
+++ b/src/main/scala/nl/knaw/dans/narcis/graphql/app/rest/HttpWorker.scala
@@ -1,0 +1,78 @@
+/**
+ * Copyright (C) 2019 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.narcis.graphql.app.rest
+
+import nl.knaw.dans.lib.logging.DebugEnhancedLogging
+import nl.knaw.dans.narcis.graphql.HttpException
+import org.json4s._
+import org.json4s.native.{JsonMethods, Serialization}
+import scalaj.http.BaseHttp
+
+import scala.util.Try
+
+class HttpWorker(appVersion: String) extends DebugEnhancedLogging {
+  object Http extends BaseHttp(userAgent = s"narcis-graphql/$appVersion")
+
+  def getJsonData[T: Manifest](url: String, connTimeoutMs: Int = Int.MaxValue,
+                               readTimeoutMs: Int = Int.MaxValue)
+                              (implicit formats: Formats): Try[T] = Try {
+    logger.info(s"fetching data from $url")
+
+    val response = Http(url)
+      .timeout(connTimeoutMs, readTimeoutMs)
+      .asString
+
+    if (response.isSuccess) {
+      val body = response.body
+
+      if (logger.underlying.isDebugEnabled)
+        logger.debug(s"fetched body:\n$body")
+
+      JsonMethods.parse(body).extract[T]
+    }
+    else {
+      if (logger.underlying.isDebugEnabled)
+        logger.debug(s"fetching data from $url failed: ${ response.code } - ${ response.body }")
+
+      throw HttpException("GET", url, response.code, response.body)
+    }
+  }
+
+  def postJsonData[T <: AnyRef](url: String, data: T, connTimeoutMs: Int = Int.MaxValue,
+                                readTimeoutMs: Int = Int.MaxValue)
+                               (implicit formats: Formats): Try[Unit] = Try {
+    logger.info(s"posting data to $url")
+
+    val response = Http(url)
+      .timeout(connTimeoutMs, readTimeoutMs)
+      .postData(Serialization.write[T](data))
+      .header("content-type", "application/json")
+      .asString
+
+    if (response.isSuccess) {
+      val body = response.body
+
+      if (logger.underlying.isDebugEnabled)
+        logger.debug(s"fetched body:\n$body")
+    }
+    else {
+      if (logger.underlying.isDebugEnabled)
+        logger.debug(s"posting data to $url failed: ${ response.code } - ${ response.body }")
+
+      throw HttpException("POST", url, response.code, response.body)
+    }
+  }
+}

--- a/src/main/scala/nl/knaw/dans/narcis/graphql/app/rest/PidGraphData.scala
+++ b/src/main/scala/nl/knaw/dans/narcis/graphql/app/rest/PidGraphData.scala
@@ -1,0 +1,128 @@
+/**
+ * Copyright (C) 2019 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.narcis.graphql.app.rest
+
+import nl.knaw.dans.narcis.graphql.app.rest.KnownGraphTypes.KnownGraphType
+import nl.knaw.dans.narcis.graphql.app.rest.PersonPidType.PersonPidType
+import nl.knaw.dans.narcis.graphql.app.rest.WorkPidType.WorkPidType
+import nl.knaw.dans.narcis.graphql.app.rest.WorkType.WorkType
+import org.json4s.ext.EnumNameSerializer
+import org.json4s.{DefaultFormats, Formats}
+
+object PersonPidType extends Enumeration {
+  type PersonPidType = Value
+
+  // @formatter:off
+  val publication   = Value("publication")
+  val dai_nl        = Value("dai-nl")
+  val isni          = Value("isni")
+  val loop          = Value("loop")
+  val nod_person    = Value("nod-person")
+  val orcid         = Value("orcid")
+  val researcherid  = Value("researcherid")
+  val scopus        = Value("scopus")
+  val viaf          = Value("viaf")
+  // @formatter:on
+}
+
+object WorkPidType extends Enumeration {
+  type WorkPidType = Value
+
+  // @formatter:off
+  val arxiv          = Value("arxiv")
+  val doi            = Value("doi")
+  val eid            = Value("eid")
+  val handle         = Value("handle")
+  val narcis_oaipub  = Value("narcis-oaipub")
+  val pmc            = Value("pmc")
+  val pmid           = Value("pmid")
+  val purl           = Value("purl")
+  val urn_nbn        = Value("urn:nbn")
+  val wosuid         = Value("wosuid")
+  // @formatter:on
+}
+
+object WorkType extends Enumeration {
+  type WorkType = Value
+
+  // @formatter:off
+  val publication            = Value("publication")
+  val journalArticle         = Value("journal-article")
+  val dataset                = Value("dataset")
+  val software               = Value("software")
+  val conferencePaper        = Value("conference-paper")
+  val book                   = Value("book")
+  val bookChapter            = Value("book-chapter")
+  val dataSet                = Value("data-set")
+  val report                 = Value("report")
+  val dissertation           = Value("dissertation")
+  val workingPaper           = Value("working-paper")
+  val bookReview             = Value("book-review")
+  val bookPart               = Value("book-part")
+  val annotation             = Value("annotation")
+  val lecture                = Value("lecture")
+  val conferenceObject       = Value("conference-object")
+  val conferenceProceedings  = Value("conference-proceedings")
+  val patent                 = Value("patent")
+  val preprint               = Value("preprint")
+  val review                 = Value("review")
+  val conferenceItem         = Value("conference-item")
+  val masterThesis           = Value("master-thesis")
+  val studentThesis          = Value("student-thesis")
+  val bachelorThesis         = Value("bachelor-thesis")
+  val technicaldocumentation = Value("technicaldocumentation")
+  val other                  = Value("other")
+  // @formatter:on
+}
+
+// The following 'type' information is from graph database tables, and can be extended
+// Maybe these can be retrieved from the graph database
+object KnownGraphTypes extends Enumeration {
+  type KnownGraphType = Value
+
+  val NarcisIdx: KnownGraphType = Value("narcis-idx")
+  val Orcid: KnownGraphType = Value("orcid")
+  val SysVsoi: KnownGraphType = Value("sysvsoi")
+}
+
+case class GraphPersonPid(
+                           source: KnownGraphType,
+                           pidType: PersonPidType,
+                           value: String,
+                         )
+
+case class GraphWorkPid(
+                         source: KnownGraphType,
+                         pidType: WorkPidType,
+                         value: String,
+                       )
+
+case class GraphPerson(
+                        id: String, // the PRS ID
+                        pids: Seq[GraphPersonPid],
+                      )
+
+case class GraphWork(
+                      title: String, // Work.title
+                      entitytype: WorkType,
+                      date: String, // publication date maybe DateTime?
+                      pids: Seq[GraphWorkPid],
+                    )
+
+case class PidGraphData(person: GraphPerson, works: Seq[GraphWork])
+object PidGraphData {
+  implicit val jsonFormats: Formats = new DefaultFormats {} ++ List(WorkType, WorkPidType, PersonPidType, KnownGraphTypes).map(new EnumNameSerializer(_))
+}

--- a/src/main/scala/nl/knaw/dans/narcis/graphql/package.scala
+++ b/src/main/scala/nl/knaw/dans/narcis/graphql/package.scala
@@ -19,4 +19,6 @@ import org.json4s.JValue
 
 package object graphql {
   case class GraphQLInput(query: String, variables: Option[JValue], operationName: Option[String])
+
+  case class HttpException(method: String, url: String, code: Int, msg: String) extends Exception(s"$method request failed for url $url with code $code and message '$msg'")
 }

--- a/src/test/resources/debug-config/application.properties
+++ b/src/test/resources/debug-config/application.properties
@@ -7,6 +7,8 @@
 daemon.http.port=8012
 graphql.profiling.threshold=100
 
+pidgraph.url=https://test.pidgraph.narcis.nl
+
 sysvsoi.database.driver-class=com.mysql.jdbc.Driver
 sysvsoi.database.url=jdbc:mysql://tvsoi11.dans.knaw.nl:3306/sysvsoi
 sysvsoi.database.username=narcis_portal

--- a/src/test/scala/nl/knaw/dans/narcis/graphql/ReadmeSpec.scala
+++ b/src/test/scala/nl/knaw/dans/narcis/graphql/ReadmeSpec.scala
@@ -31,7 +31,8 @@ class ReadmeSpec extends FlatSpec with Matchers with CustomMatchers {
     version = "my-version",
     serverPort = 12345,
     profilingThreshold = 12 seconds,
-    sysvsoiConfig = DatabaseConfiguration("", "")
+    sysvsoiConfig = DatabaseConfiguration("", ""),
+    pidGraphUrl = ""
   )
   private val clo = new CommandLineOptions(Array[String](), configuration) {
     // avoids System.exit() in case of invalid arguments or "--help"


### PR DESCRIPTION
Now extracts and merges information from the vsoi and pidgraph (test services)
 @DANS-KNAW/narcis can test it with the following 

request:
```
query {
    person(id: "PRS1326072") {
        id
        name
        email
        externalIds {
            type
            value
        }
    }
}

```
result:
```
{
  "data": {
    "person": {
      "id": "PRS1326072",
      "name": "Schijven",
      "email": null,
      "externalIds": [
        {
          "type": "researcherid",
          "value": "B-9767-2016"
        },
        {
          "type": "isni",
          "value": "0000000393537060"
        },
        {
          "type": "nod_person",
          "value": "PRS1326072"
        },
        {
          "type": "dai_nl",
          "value": "273313045"
        },
        {
          "type": "scopus",
          "value": "6602492995"
        },
        {
          "type": "orcid",
          "value": "0000-0001-7013-0116"
        }
      ]
    }
  }
}
```